### PR TITLE
Allow users to override the list of PostGIS dependencies...

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,11 @@ postgresql_ext_install_postgis: no
 
 postgresql_ext_postgis_version: "2.1" # be careful: check whether the postgresql/postgis versions work together
 
+postgresql_ext_postgis_deps:
+  - libgeos-c1
+  - "postgresql-{{ postgresql_version }}-postgis-{{ postgresql_ext_postgis_version }}"
+  - "postgresql-{{ postgresql_version }}-postgis-scripts"
+
 # List of databases to be created (optional)
 postgresql_databases: []
 

--- a/tasks/extensions/postgis.yml
+++ b/tasks/extensions/postgis.yml
@@ -2,13 +2,9 @@
 
 - name: PostgreSQL | Extensions | Make sure the postgis extensions are installed
   apt:
-    name: "{{item}}"
+    name: "{{postgresql_ext_postgis_deps}}"
     state: present
     update_cache: yes
     cache_valid_time: "{{apt_cache_valid_time | default (3600)}}"
-  with_items:
-    - libgeos-c1
-    - "postgresql-{{postgresql_version}}-postgis-{{postgresql_ext_postgis_version}}"
-    - "postgresql-{{postgresql_version}}-postgis-scripts"
   notify:
     - restart postgresql


### PR DESCRIPTION
... because it seems like the format of the postgis-scripts package has
changed?

This is a bit odd, but let me explain!

I wanted to install a local geodata and it told me I needed the gapidb VM, so I went to follow those instructions.

When I followed those instructions, I always failed on the step where PostGIS extenstions get installed, because the scripts package cannot be found.

When I look in this repo, I see that we try to install:

    postgresql-{{ postgresql_version }}-postgis-scripts

However when I jump into the gapidb VM and did some searches in apt I found that the packages available for old postgres *do* match that pattern:

    $ sudo apt search postgis | grep postgis-scripts

    postgresql-9.0-postgis-scripts/trusty-pgdg 2.1.8+dfsg-5~97.git43a09cc.pgdg14.04+1 all
    postgresql-9.1-postgis-scripts/trusty-pgdg 2.2.2+dfsg-5.pgdg14.04+1 all
    postgresql-9.2-postgis-scripts/trusty-pgdg 2.3.3+dfsg-1.pgdg14.04+1 all
    postgresql-9.3-postgis-scripts/trusty-pgdg 2.4.4+dfsg-4.pgdg14.04+1 all

... and for newer postgres, they do not match that pattern:

    $ sudo apt search postgis | grep postgis | grep 9.6

    postgresql-9.6-postgis-2.3/trusty-pgdg 2.3.3+dfsg-1.pgdg14.04+1 amd64
    postgresql-9.6-postgis-2.3-scripts/trusty-pgdg 2.3.3+dfsg-1.pgdg14.04+1 all
    postgresql-9.6-postgis-2.4/trusty-pgdg 2.4.4+dfsg-4.pgdg14.04+1 amd64
    postgresql-9.6-postgis-2.4-scripts/trusty-pgdg 2.4.4+dfsg-4.pgdg14.04+1 all

(IIRC Postgres 9.5 packages follow this format as well, but has PostGIS 2.2 - 2.4 available)

ANYHOW!

I tried quickly installing `ANXS/postgresql` instead of our fork and that didn't work straightaway, so I adapted an idea I stole from them:

Define the default list of dependencies in defaults so that users can override if they like.

See:
    https://github.com/ANXS/postgresql/blob/d8fc0d33/tasks/extensions/postgis.yml
    https://github.com/ANXS/postgresql/blob/d8fc0d33/defaults/main.yml

(Here is the [companion PR for ansible-gapi to use this capability and make it possible to provision a gapidb again](https://github.com/gadventures/ansible-gapi/pull/86))